### PR TITLE
Improve bulk generator layout

### DIFF
--- a/src/components/bulk/PresetControls.jsx
+++ b/src/components/bulk/PresetControls.jsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+
+const STORAGE_KEY = 'bulkLayoutPresets';
+
+const PresetControls = ({ layout, applyLayout }) => {
+  const [presets, setPresets] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem(STORAGE_KEY)) || {};
+    } catch {
+      return {};
+    }
+  });
+  const [selected, setSelected] = useState('');
+
+  const savePreset = () => {
+    const name = prompt('Preset name');
+    if (!name) return;
+    const newPresets = { ...presets, [name]: layout };
+    setPresets(newPresets);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(newPresets));
+    setSelected(name);
+  };
+
+  const loadPreset = (name) => {
+    setSelected(name);
+    if (presets[name]) applyLayout(presets[name]);
+  };
+
+  return (
+    <div className="flex gap-2 items-center">
+      <select
+        value={selected}
+        onChange={(e) => loadPreset(e.target.value)}
+        className="border rounded p-1 flex-1"
+      >
+        <option value="">Presets</option>
+        {Object.keys(presets).map((k) => (
+          <option key={k} value={k}>{k}</option>
+        ))}
+      </select>
+      <button onClick={savePreset} className="px-2 py-1 bg-blue-600 text-white rounded">Save</button>
+    </div>
+  );
+};
+
+export default PresetControls;

--- a/src/components/bulk/SidebarSection.jsx
+++ b/src/components/bulk/SidebarSection.jsx
@@ -1,0 +1,20 @@
+import React, { useState } from 'react';
+
+const SidebarSection = ({ title, children, defaultOpen = true }) => {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="border rounded mb-2">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="w-full flex justify-between items-center px-2 py-1 bg-gray-200"
+      >
+        <span className="font-medium">{title}</span>
+        <span>{open ? '-' : '+'}</span>
+      </button>
+      {open && <div className="p-2 space-y-2">{children}</div>}
+    </div>
+  );
+};
+
+export default SidebarSection;

--- a/src/components/bulk/ZoomControls.jsx
+++ b/src/components/bulk/ZoomControls.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const ZoomControls = ({ zoom, setZoom }) => {
+  const dec = () => setZoom(z => Math.max(0.1, +(z - 0.1).toFixed(2)));
+  const inc = () => setZoom(z => Math.min(3, +(z + 0.1).toFixed(2)));
+  return (
+    <div className="flex items-center gap-2 p-2">
+      <button onClick={dec} className="px-2 py-1 bg-gray-200 rounded">-</button>
+      <span className="text-sm">{Math.round(zoom * 100)}%</span>
+      <button onClick={inc} className="px-2 py-1 bg-gray-200 rounded">+</button>
+    </div>
+  );
+};
+
+export default ZoomControls;


### PR DESCRIPTION
## Summary
- refactor BulkGenerator page
- add SidebarSection, ZoomControls and PresetControls components
- make sidebar collapsible, scrollable and fixed width
- add live preview zoom and layout preset saving
- remove duplicate bulk-canvas element

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6880e8c475188322b02f209e2d098b06