### PR TITLE
Add template editing modal and sidebar

### DIFF
--- a/src/components/CanvasEditor.jsx
+++ b/src/components/CanvasEditor.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import toast, { Toaster } from 'react-hot-toast';
 import { useCanvasEditor } from "../hooks/useCanvasEditor";
 import { useCanvasTools } from "../hooks/useCanvasTools";
 import CanvasArea from "./CanvasArea";
@@ -28,8 +29,9 @@ import { useParams } from "react-router-dom";
 
 const LOCAL_KEY = "localTemplates";
 
-const CanvasEditor = () => {
-  const { templateId } = useParams();
+const CanvasEditor = ({ templateId: propTemplateId, onSaved }) => {
+  const { templateId: routeId } = useParams();
+  const templateId = propTemplateId || routeId;
   const [students, setStudents] = useState([]);
   const [selectedStudent, setSelectedStudent] = useState(null);
    const [institutes, setInstitutes] = useState([]);
@@ -265,21 +267,20 @@ const saveTemplateLayout = async () => {
   template: templateId || null, // ✅ use templateId from URL
 };
 
-await axios.post(`https://canvaback.onrender.com/api/templatelayout/save`, payload);
-
-
   try {
-    const res = await axios.post("https://canvaback.onrender.com/api/templatelayout/save", payload);
-    alert("✅ Template saved successfully!");
+    await axios.post(`https://canvaback.onrender.com/api/templatelayout/save`, payload);
+    toast.success('Template saved successfully');
+    onSaved?.();
   } catch (error) {
     console.error("❌ Failed to save template", error);
-    alert("Error saving template.");
+    toast.error('Error saving template');
   }
 };
 
 
   return (
      <div className="h-screen flex flex-col">
+      <Toaster position="top-right" />
       <header className="h-12 bg-gray-800 text-white flex items-center px-4 gap-4">
         <a href="/" className="font-bold">Framee</a>
         <a href="/templates" className="underline">Templates</a>

--- a/src/components/CanvasEditorModal.jsx
+++ b/src/components/CanvasEditorModal.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import Modal from './common/Modal';
+import CanvasEditor from './CanvasEditor';
+
+const CanvasEditorModal = ({ templateId, onClose, onSaved }) => (
+  <Modal title="Edit Template" onClose={onClose}>
+    <CanvasEditor templateId={templateId} onSaved={onSaved} />
+  </Modal>
+);
+
+export default CanvasEditorModal;

--- a/src/components/bulk/RightSidebar.jsx
+++ b/src/components/bulk/RightSidebar.jsx
@@ -1,20 +1,22 @@
 import React from 'react';
 
-const RightSidebar = ({ show, students }) => (
+const RightSidebar = ({ show, templates, onSelect }) => (
   <aside className={`bg-gray-50 w-64 p-4 overflow-y-auto space-y-2 ${show ? 'block' : 'hidden'} md:block`}>
-    <h2 className="font-medium">Students</h2>
+    <h2 className="font-medium">Templates</h2>
     <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-      {students.map((student, idx) => (
-        <div key={idx} className="p-2 bg-white rounded shadow text-center">
+      {templates.map((tpl) => (
+        <button
+          key={tpl.id}
+          onClick={() => onSelect(tpl)}
+          className="p-2 bg-white rounded shadow text-center hover:bg-gray-100"
+        >
           <img
-            src={student.photo?.[0] || 'https://via.placeholder.com/100?text=No+Photo'}
-            alt={`${student.firstName} ${student.lastName}`}
-            className="w-12 h-12 mx-auto rounded-full object-cover mb-1 border"
+            src={tpl.image}
+            alt={tpl.title}
+            className="w-full h-20 object-cover mb-1 border rounded"
           />
-          <p className="text-xs font-medium truncate">
-            {student.firstName} {student.lastName}
-          </p>
-        </div>
+          <p className="text-xs font-medium truncate">{tpl.title}</p>
+        </button>
       ))}
     </div>
   </aside>


### PR DESCRIPTION
## Summary
- make `CanvasEditor` reusable with props and toast alerts
- add modal wrapper for `CanvasEditor`
- show template thumbnails in BulkGenerator right sidebar
- allow editing templates inside BulkGenerator

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint')*

------
https://chatgpt.com/codex/tasks/task_e_6887062395bc8322a066ed3e93131b5a