### PR TITLE
Add template preview sidebar and use inches

### DIFF
--- a/src/components/bulk/LeftSidebar.jsx
+++ b/src/components/bulk/LeftSidebar.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import SidebarSection from './SidebarSection';
 import PresetControls from './PresetControls';
 
+const DPI = 300;
+
 const LeftSidebar = ({
   show,
   templates,
@@ -73,20 +75,20 @@ const LeftSidebar = ({
         {size === 'custom' && (
           <>
             <div className="flex flex-col">
-              <label className="text-sm font-medium">Page Width</label>
+              <label className="text-sm font-medium">Page Width (in)</label>
               <input
                 type="number"
-                value={custom.width}
-                onChange={e => setCustom({ ...custom, width: Number(e.target.value) })}
+                value={custom.width / DPI}
+                onChange={e => setCustom({ ...custom, width: Math.round(Number(e.target.value) * DPI) })}
                 className="border p-2 rounded"
               />
             </div>
             <div className="flex flex-col">
-              <label className="text-sm font-medium">Page Height</label>
+              <label className="text-sm font-medium">Page Height (in)</label>
               <input
                 type="number"
-                value={custom.height}
-                onChange={e => setCustom({ ...custom, height: Number(e.target.value) })}
+                value={custom.height / DPI}
+                onChange={e => setCustom({ ...custom, height: Math.round(Number(e.target.value) * DPI) })}
                 className="border p-2 rounded"
               />
             </div>
@@ -116,29 +118,29 @@ const LeftSidebar = ({
           />
         </div>
         <div className="flex flex-col">
-          <label className="text-sm font-medium">Left Margin</label>
+          <label className="text-sm font-medium">Left Margin (in)</label>
           <input
             type="number"
-            value={margins.left}
-            onChange={e => setMargins({ ...margins, left: Number(e.target.value) })}
+            value={margins.left / DPI}
+            onChange={e => setMargins({ ...margins, left: Math.round(Number(e.target.value) * DPI) })}
             className="border p-2 rounded"
           />
         </div>
         <div className="flex flex-col">
-          <label className="text-sm font-medium">Right Margin</label>
+          <label className="text-sm font-medium">Right Margin (in)</label>
           <input
             type="number"
-            value={margins.right}
-            onChange={e => setMargins({ ...margins, right: Number(e.target.value) })}
+            value={margins.right / DPI}
+            onChange={e => setMargins({ ...margins, right: Math.round(Number(e.target.value) * DPI) })}
             className="border p-2 rounded"
           />
         </div>
         <div className="flex flex-col">
-          <label className="text-sm font-medium">Top Margin</label>
+          <label className="text-sm font-medium">Top Margin (in)</label>
           <input
             type="number"
-            value={margins.top}
-            onChange={e => setMargins({ ...margins, top: Number(e.target.value) })}
+            value={margins.top / DPI}
+            onChange={e => setMargins({ ...margins, top: Math.round(Number(e.target.value) * DPI) })}
             className="border p-2 rounded"
           />
         </div>

--- a/src/components/bulk/RightSidebar.jsx
+++ b/src/components/bulk/RightSidebar.jsx
@@ -1,25 +1,52 @@
 import React from 'react';
 
-const RightSidebar = ({ show, templates, onSelect }) => (
-  <aside className={`bg-gray-50 w-64 p-4 overflow-y-auto space-y-2 ${show ? 'block' : 'hidden'} md:block`}>
-    <h2 className="font-medium">Templates</h2>
-    <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-      {templates.map((tpl) => (
-        <button
-          key={tpl.id}
-          onClick={() => onSelect(tpl)}
-          className="p-2 bg-white rounded shadow text-center hover:bg-gray-100"
-        >
-          <img
-            src={tpl.image}
-            alt={tpl.title}
-            className="w-full h-20 object-cover mb-1 border rounded"
-          />
-          <p className="text-xs font-medium truncate">{tpl.title}</p>
-        </button>
-      ))}
-    </div>
-  </aside>
-);
+const RightSidebar = ({
+  show,
+  templates,
+  selectedTemplate,
+  previewUrl,
+  onSelect,
+  onBack,
+}) => {
+  if (!selectedTemplate) {
+    return (
+      <aside
+        className={`bg-gray-50 w-64 p-4 overflow-y-auto space-y-2 ${show ? 'block' : 'hidden'} md:block`}
+      >
+        <h2 className="font-medium">Templates</h2>
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+          {templates.map((tpl) => (
+            <button
+              key={tpl.id}
+              onClick={() => onSelect(tpl)}
+              className="p-2 bg-white rounded shadow text-center hover:bg-gray-100"
+            >
+              <img
+                src={tpl.image}
+                alt={tpl.title}
+                className="w-full h-20 object-cover mb-1 border rounded"
+              />
+              <p className="text-xs font-medium truncate">{tpl.title}</p>
+            </button>
+          ))}
+        </div>
+      </aside>
+    );
+  }
+
+  return (
+    <aside
+      className={`bg-gray-50 w-64 p-4 overflow-y-auto space-y-2 ${show ? 'block' : 'hidden'} md:block`}
+    >
+      <h2 className="font-medium mb-2">Preview</h2>
+      {previewUrl && (
+        <img src={previewUrl} alt="Preview" className="w-full mb-2 border rounded" />
+      )}
+      <button onClick={onBack} className="w-full bg-gray-200 rounded p-2">
+        Change Template
+      </button>
+    </aside>
+  );
+};
 
 export default RightSidebar;

--- a/src/components/bulk/RightSidebar.jsx
+++ b/src/components/bulk/RightSidebar.jsx
@@ -5,6 +5,7 @@ const RightSidebar = ({
   templates,
   selectedTemplate,
   previewUrl,
+  pagePreviewUrl,
   onSelect,
   onBack,
 }) => {
@@ -41,6 +42,9 @@ const RightSidebar = ({
       <h2 className="font-medium mb-2">Preview</h2>
       {previewUrl && (
         <img src={previewUrl} alt="Preview" className="w-full mb-2 border rounded" />
+      )}
+      {pagePreviewUrl && (
+        <img src={pagePreviewUrl} alt="Page Preview" className="w-full mb-2 border rounded" />
       )}
       <button onClick={onBack} className="w-full bg-gray-200 rounded p-2">
         Change Template


### PR DESCRIPTION
## Summary
- preview selected template and student data in right sidebar
- show page width, height and margins in inches in left sidebar

## Testing
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_688720e70d548322a8cd9f1c7f6ddb66