### PR TITLE
Enable responsive canvas scaling and frame dragging

### DIFF
--- a/src/components/CanvasArea.jsx
+++ b/src/components/CanvasArea.jsx
@@ -17,7 +17,7 @@ const CanvasArea = forwardRef(({ width, height }, ref) => {
   }, [width, height, ref]);
 
   return (
-    <div className="bg-white shadow border">
+    <div className="bg-white shadow border w-full h-full">
       <canvas id="main-canvas" />
     </div>
   );

--- a/src/hooks/useCanvasEditor.js
+++ b/src/hooks/useCanvasEditor.js
@@ -75,10 +75,13 @@ export function useCanvasEditor(canvasRef, canvasWidth, canvasHeight) {
   const downloadPDF = () => {
     if (!canvas) return;
     sanitizeTextStyles();
+    const prevVpt = canvas.viewportTransform.slice();
+    canvas.setViewportTransform([1, 0, 0, 1, 0, 0]);
     const dataUrl = canvas.toDataURL({ format: "png" });
     const pdf = new jsPDF("l", "px", [canvasWidth, canvasHeight]);
     pdf.addImage(dataUrl, "PNG", 0, 0, canvasWidth, canvasHeight);
     pdf.save("design.pdf");
+    canvas.setViewportTransform(prevVpt);
   };
 
  const downloadHighRes = () => {
@@ -86,6 +89,8 @@ export function useCanvasEditor(canvasRef, canvasWidth, canvasHeight) {
   sanitizeTextStyles();
   canvas.discardActiveObject();
   canvas.renderAll();
+  const prevVpt = canvas.viewportTransform.slice();
+  canvas.setViewportTransform([1, 0, 0, 1, 0, 0]);
 
   requestAnimationFrame(() => {
     const dataUrl = canvas.toDataURL({
@@ -97,6 +102,8 @@ export function useCanvasEditor(canvasRef, canvasWidth, canvasHeight) {
     link.download = "canvas-image.png";
     link.href = dataUrl;
     link.click();
+    canvas.setViewportTransform(prevVpt);
+    canvas.requestRenderAll();
   });
 };
 

--- a/src/hooks/useCanvasTools.js
+++ b/src/hooks/useCanvasTools.js
@@ -101,10 +101,14 @@ export function useCanvasTools({ width, height }) {
   const download = () => {
     const canvas = canvasRef.current;
     if (!canvas) return;
+    const prevVpt = canvas.viewportTransform.slice();
+    canvas.setViewportTransform([1, 0, 0, 1, 0, 0]);
     const link = document.createElement("a");
     link.href = canvas.toDataURL({ format: "png" });
     link.download = "canvas.png";
     link.click();
+    canvas.setViewportTransform(prevVpt);
+    canvas.requestRenderAll();
   };
 
   const cropImage = () => {


### PR DESCRIPTION
## Summary
- scale canvas to match template pixels and fit 90vh view using Fabric zoom
- allow dragging image or frame together after masking and preserve adjust mode
- export images and PDFs at real size by resetting viewport

## Testing
- `npm run lint` (fails: Plugin "" not found)
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b86ff2862c8322bf28195091921dc9