### PR TITLE
refactor: split canvas editor into reusable components

### DIFF
--- a/src/components/BottomToolbar.jsx
+++ b/src/components/BottomToolbar.jsx
@@ -1,0 +1,53 @@
+import React from "react";
+import IconButton from "./IconButton";
+import {
+  AlignLeft as AlignLeftIcon,
+  AlignCenter as AlignCenterIcon,
+  AlignRight as AlignRightIcon,
+  AlignStartVertical,
+  AlignVerticalSpaceAround,
+  AlignEndVertical,
+  ArrowUpFromLine,
+  ArrowDownToLine,
+} from "lucide-react";
+
+const BottomToolbar = ({
+  alignLeft,
+  alignCenter,
+  alignRight,
+  alignTop,
+  alignMiddle,
+  alignBottom,
+  bringToFront,
+  sendToBack,
+}) => (
+  <div className="fixed bottom-0 w-full bg-white border-t shadow z-30 px-2 py-2 overflow-x-auto scrollbar-thin flex justify-start items-center gap-1">
+    <IconButton onClick={alignLeft} title="Align Left">
+      <AlignLeftIcon size={22} />
+    </IconButton>
+    <IconButton onClick={alignCenter} title="Align Center">
+      <AlignCenterIcon size={22} />
+    </IconButton>
+    <IconButton onClick={alignRight} title="Align Right">
+      <AlignRightIcon size={22} />
+    </IconButton>
+    <IconButton onClick={alignTop} title="Align Top">
+      <AlignStartVertical size={22} />
+    </IconButton>
+    <IconButton onClick={alignMiddle} title="Align Middle">
+      <AlignVerticalSpaceAround size={22} />
+    </IconButton>
+    <IconButton onClick={alignBottom} title="Align Bottom">
+      <AlignEndVertical size={22} />
+    </IconButton>
+    <IconButton onClick={bringToFront} title="Bring to Front">
+      <ArrowUpFromLine size={22} />
+    </IconButton>
+    <IconButton onClick={sendToBack} title="Send to Back">
+      <ArrowDownToLine size={22} />
+    </IconButton>
+  </div>
+);
+
+export default BottomToolbar;
+

--- a/src/components/IconButton.jsx
+++ b/src/components/IconButton.jsx
@@ -1,17 +1,16 @@
 // IconButton.jsx
 import React from "react";
 
-const IconButton = ({ onClick, title, children, className = "" }) => {
-  return (
-    <button
-      onClick={onClick}
-      title={title}
-      className={`p-2 rounded bg-white shadow hover:bg-blue-100 ${className}`.trim()}
-      type="button"
-    >
-      {children}
-    </button>
-  );
-};
+const IconButton = ({ onClick, title, children, className = "", ...props }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    title={title}
+    className={`p-2 rounded bg-white shadow hover:bg-blue-100 ${className}`}
+    {...props}
+  >
+    {children}
+  </button>
+);
 
 export default IconButton;

--- a/src/components/IconButton.jsx
+++ b/src/components/IconButton.jsx
@@ -7,6 +7,7 @@ const IconButton = ({ onClick, title, children, className = "" }) => {
       onClick={onClick}
       title={title}
       className={`p-2 rounded bg-white shadow hover:bg-blue-100 ${className}`.trim()}
+      type="button"
     >
       {children}
     </button>

--- a/src/components/UndoRedoControls.jsx
+++ b/src/components/UndoRedoControls.jsx
@@ -4,10 +4,18 @@ import IconButton from "./IconButton";
 
 const UndoRedoControls = ({ undo, redo, duplicateObject, downloadPDF }) => (
   <div className="flex gap-2">
-    <IconButton onClick={undo}>Undo</IconButton>
-    <IconButton onClick={redo}>Redo</IconButton>
-    <IconButton onClick={duplicateObject}>Duplicate</IconButton>
-    <IconButton onClick={downloadPDF}>PDF</IconButton>
+    <IconButton onClick={undo} title="Undo">
+      Undo
+    </IconButton>
+    <IconButton onClick={redo} title="Redo">
+      Redo
+    </IconButton>
+    <IconButton onClick={duplicateObject} title="Duplicate">
+      Duplicate
+    </IconButton>
+    <IconButton onClick={downloadPDF} title="Export PDF">
+      PDF
+    </IconButton>
   </div>
 );
 

--- a/src/components/UndoRedoControls.jsx
+++ b/src/components/UndoRedoControls.jsx
@@ -1,20 +1,21 @@
 
 import React from "react";
 import IconButton from "./IconButton";
+import { Undo, Redo, Copy, FileDown } from "lucide-react";
 
 const UndoRedoControls = ({ undo, redo, duplicateObject, downloadPDF }) => (
   <div className="flex gap-2">
     <IconButton onClick={undo} title="Undo">
-      Undo
+      <Undo size={22} />
     </IconButton>
     <IconButton onClick={redo} title="Redo">
-      Redo
+      <Redo size={22} />
     </IconButton>
     <IconButton onClick={duplicateObject} title="Duplicate">
-      Duplicate
+      <Copy size={22} />
     </IconButton>
     <IconButton onClick={downloadPDF} title="Export PDF">
-      PDF
+      <FileDown size={22} />
     </IconButton>
   </div>
 );


### PR DESCRIPTION
## Summary
- extract bottom toolbar into new component
- replace inline helper components in `CanvasEditor.jsx` with imports
- add button type and titles for more reusable `IconButton` and `UndoRedoControls`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 99 errors, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_68b882c5547483228e8d67d2f65562f3