### PR TITLE
refactor: rename worksheet variables

### DIFF
--- a/src/Pages/BulkGenerator.jsx
+++ b/src/Pages/BulkGenerator.jsx
@@ -94,7 +94,7 @@ const BulkGenerator = () => {
         resolve();
       }));
       setSelected(tplId);
-    } catch (e) {
+    } catch {
       toast.error('Failed to load template');
     }
   };
@@ -156,8 +156,8 @@ const BulkGenerator = () => {
     const reader = new FileReader();
     reader.onload = (evt) => {
       const wb = XLSX.read(evt.target.result, { type: 'binary' });
-      const ws = wb.Sheets[wb.SheetNames[0]];
-      const json = XLSX.utils.sheet_to_json(ws);
+      const worksheet = wb.Sheets[wb.SheetNames[0]];
+      const json = XLSX.utils.sheet_to_json(worksheet);
       setRows(json);
       setIndex(0);
     };
@@ -312,7 +312,7 @@ const drawImageWithText = async (ctx, student, x, y, width, height, imageUrl) =>
     }
   };
 
- const downloadLayout = async (format) => {
+ const downloadLayout = async () => {
   if (!selected || rows.length === 0) return;
 
   const baseSize = size === 'A4' ? A4 : size === 'A3' ? A3 : custom;

--- a/src/pages/Courses.jsx
+++ b/src/pages/Courses.jsx
@@ -37,7 +37,7 @@ const Courses = () => {
       setLoading(true);
       const res = await axios.get(`${BASE_URL}/api/courses`);
       setCourses(res.data || []);
-    } catch (err) {
+    } catch {
       toast.error('Failed to fetch courses');
     } finally {
       setLoading(false);
@@ -70,7 +70,7 @@ const Courses = () => {
       setEditingId(null);
       setShowModal(false);
       fetchCourses();
-    } catch (err) {
+    } catch {
       toast.error('Failed to submit');
     }
   };
@@ -118,16 +118,18 @@ const Courses = () => {
   };
 
   const exportExcel = () => {
-    const ws = XLSX.utils.json_to_sheet(filteredCourses.map(c => ({
-      'Course Name': c.name,
-      Description: c.description,
-      'Course Fees': c.courseFees,
-      'Exam Fees': c.examFees,
-      Duration: c.duration
-    })));
-    const wb = XLSX.utils.book_new();
-    XLSX.utils.book_append_sheet(wb, ws, 'Courses');
-    XLSX.writeFile(wb, 'courses.xlsx');
+    const worksheet = XLSX.utils.json_to_sheet(
+      filteredCourses.map(c => ({
+        'Course Name': c.name,
+        Description: c.description,
+        'Course Fees': c.courseFees,
+        'Exam Fees': c.examFees,
+        Duration: c.duration,
+      }))
+    );
+    const workbook = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(workbook, worksheet, 'Courses');
+    XLSX.writeFile(workbook, 'courses.xlsx');
   };
 
   return (

--- a/src/pages/Students.jsx
+++ b/src/pages/Students.jsx
@@ -42,7 +42,7 @@ const Students = () => {
       const res = await axios.get(`${BASE_URL}/api/students`);
 setStudents(Array.isArray(res.data?.data) ? res.data.data : []);
 
-    } catch (err) {
+    } catch {
       toast.error('Failed to fetch students');
     } finally {
       setLoading(false);
@@ -92,7 +92,7 @@ setStudents(Array.isArray(res.data?.data) ? res.data.data : []);
     setEditingId(null);
     setShowModal(false);
     fetchStudents();
-  } catch (err) {
+  } catch {
     toast.error('Failed to submit');
   }
 };
@@ -143,17 +143,19 @@ setStudents(Array.isArray(res.data?.data) ? res.data.data : []);
   };
 
   const exportExcel = () => {
-    const ws = XLSX.utils.json_to_sheet(filteredStudents.map(s => ({
-      'First Name': s.firstName,
-      'Middle Name': s.middleName,
-      'Last Name': s.lastName,
-      'DOB': s.dob,
-      'Gender': s.gender,
-      'Mobile': s.mobileSelf
-    })));
-    const wb = XLSX.utils.book_new();
-    XLSX.utils.book_append_sheet(wb, ws, 'Students');
-    XLSX.writeFile(wb, 'students.xlsx');
+    const worksheet = XLSX.utils.json_to_sheet(
+      filteredStudents.map(s => ({
+        'First Name': s.firstName,
+        'Middle Name': s.middleName,
+        'Last Name': s.lastName,
+        'DOB': s.dob,
+        'Gender': s.gender,
+        'Mobile': s.mobileSelf,
+      }))
+    );
+    const workbook = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(workbook, worksheet, 'Students');
+    XLSX.writeFile(workbook, 'students.xlsx');
   };
 
   return (

--- a/src/reports/AllTransaction.jsx
+++ b/src/reports/AllTransaction.jsx
@@ -110,7 +110,7 @@ const AllTransaction = () => {
             const result = await res.json();
             if (result.error) alert("Failed to send: " + result.error);
             else alert("Message sent successfully.");
-        } catch (err) {
+        } catch {
             alert("Failed to send message.");
         }
     };
@@ -132,10 +132,10 @@ const AllTransaction = () => {
 
     // Export to Excel
     const exportToExcel = () => {
-        const ws = XLSX.utils.json_to_sheet(sortedReport);
-        const wb = XLSX.utils.book_new();
-        XLSX.utils.book_append_sheet(wb, ws, 'Outstanding Report');
-        XLSX.writeFile(wb, 'outstanding_report.xlsx');
+        const worksheet = XLSX.utils.json_to_sheet(sortedReport);
+        const workbook = XLSX.utils.book_new();
+        XLSX.utils.book_append_sheet(workbook, worksheet, 'Outstanding Report');
+        XLSX.writeFile(workbook, 'outstanding_report.xlsx');
     };
 
     // Export to PDF

--- a/src/reports/allBalance.jsx
+++ b/src/reports/allBalance.jsx
@@ -14,7 +14,7 @@ const AllBalance = () => {
     const [outstandingReport, setOutstandingReport] = useState([]);
     const [sortConfig, setSortConfig] = useState({ key: 'name', direction: 'asc' });
     const [searchQuery, setSearchQuery] = useState('');
-    const [filterType, setFilterType] = useState('all');
+    const [filterType] = useState('all');
 
     const navigate = useNavigate();
     const institute_uuid = localStorage.getItem('institute_uuid');
@@ -114,10 +114,10 @@ const AllBalance = () => {
 
     // Export to Excel
     const exportToExcel = () => {
-        const ws = XLSX.utils.json_to_sheet(sortedReport);
-        const wb = XLSX.utils.book_new();
-        XLSX.utils.book_append_sheet(wb, ws, 'Outstanding Report');
-        XLSX.writeFile(wb, 'outstanding_report.xlsx');
+        const worksheet = XLSX.utils.json_to_sheet(sortedReport);
+        const workbook = XLSX.utils.book_new();
+        XLSX.utils.book_append_sheet(workbook, worksheet, 'Outstanding Report');
+        XLSX.writeFile(workbook, 'outstanding_report.xlsx');
     };
 
     // Export to PDF


### PR DESCRIPTION
## Summary
- rename worksheet variables to prevent `ws` init errors
- clean up unused variables and catches

## Testing
- `npx eslint src/Pages/BulkGenerator.jsx src/pages/Courses.jsx src/pages/Students.jsx src/reports/AllTransaction.jsx src/reports/allBalance.jsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68baa7e697988322a222a0a04c6c1aab