### PR TITLE
feat: add image background removal

### DIFF
--- a/src/components/CanvasEditor.jsx
+++ b/src/components/CanvasEditor.jsx
@@ -390,7 +390,8 @@ const CanvasEditor = ({ templateId: propTemplateId, hideHeader = false }) => {
     try {
       const res = await fetch(activeObj.getSrc());
       const blob = await res.blob();
-      const url = await removeBackground(blob);
+      const bgRemoved = await removeBackground(blob);
+      const url = URL.createObjectURL(bgRemoved);
       fabric.Image.fromURL(
         url,
         (img) => {
@@ -406,6 +407,7 @@ const CanvasEditor = ({ templateId: propTemplateId, hideHeader = false }) => {
           canvas.remove(activeObj);
           canvas.add(img);
           canvas.setActiveObject(img);
+          URL.revokeObjectURL(url);
           saveHistory();
         },
         { crossOrigin: "anonymous" }

--- a/src/utils/backgroundUtils.js
+++ b/src/utils/backgroundUtils.js
@@ -1,5 +1,3 @@
-import axios from "axios";
-
 export async function removeBackground(file) {
   const apiKey = import.meta.env.VITE_REMOVE_BG_API_KEY;
   if (!apiKey) {
@@ -10,16 +8,18 @@ export async function removeBackground(file) {
   formData.append("image_file", file);
   formData.append("size", "auto");
 
-  const response = await axios.post(
-    "https://api.remove.bg/v1.0/removebg",
-    formData,
-    {
-      headers: {
-        "X-Api-Key": apiKey,
-      },
-      responseType: "blob",
-    }
-  );
+  const response = await fetch("https://api.remove.bg/v1.0/removebg", {
+    method: "POST",
+    headers: {
+      "X-Api-Key": apiKey,
+    },
+    body: formData,
+  });
 
-  return URL.createObjectURL(response.data);
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Remove.bg request failed: ${response.status} ${errorText}`);
+  }
+
+  return await response.blob();
 }

--- a/src/utils/backgroundUtils.js
+++ b/src/utils/backgroundUtils.js
@@ -1,0 +1,25 @@
+import axios from "axios";
+
+export async function removeBackground(file) {
+  const apiKey = import.meta.env.VITE_REMOVE_BG_API_KEY;
+  if (!apiKey) {
+    throw new Error("Missing Remove.bg API key");
+  }
+
+  const formData = new FormData();
+  formData.append("image_file", file);
+  formData.append("size", "auto");
+
+  const response = await axios.post(
+    "https://api.remove.bg/v1.0/removebg",
+    formData,
+    {
+      headers: {
+        "X-Api-Key": apiKey,
+      },
+      responseType: "blob",
+    }
+  );
+
+  return URL.createObjectURL(response.data);
+}


### PR DESCRIPTION
## Summary
- support background removal using remove.bg API
- add editor control to strip backgrounds from selected images

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68beab8e6bc483228585cb1cb62d7029