### PR TITLE
Add blank canvas workflow and template sizing sync

### DIFF
--- a/src/components/CanvasArea.jsx
+++ b/src/components/CanvasArea.jsx
@@ -1,4 +1,11 @@
-import React, { useEffect, useImperativeHandle, useRef, forwardRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  forwardRef,
+  useState,
+} from "react";
 import { fabric } from "fabric";
 
 /**
@@ -8,57 +15,54 @@ import { fabric } from "fabric";
  * - Falls back to 400x550 if width/height are missing (some templates don't specify size)
  */
 const CanvasArea = forwardRef(({ width, height }, ref) => {
-  const localRef = useRef(null);
-  const [canvas, setCanvas] = useState(null);
   const canvasEl = useRef(null);
+  const [canvas, setCanvas] = useState(null);
+
+  const applyDimensions = useCallback((instance, w, h) => {
+    const dpr = window.devicePixelRatio || 1;
+
+    instance.setWidth(w);
+    instance.setHeight(h);
+    instance.setDimensions({ width: w * dpr, height: h * dpr });
+    instance.setViewportTransform([dpr, 0, 0, dpr, 0, 0]);
+
+    if (canvasEl.current) {
+      canvasEl.current.style.width = `${w}px`;
+      canvasEl.current.style.height = `${h}px`;
+    }
+
+    instance.calcOffset();
+  }, []);
 
   // Initialize Fabric canvas once
   useEffect(() => {
     const w = Number(width) || 400;
     const h = Number(height) || 550;
-    
-const c = new fabric.Canvas(canvasEl.current, {
-  width: w,
-  height: h,
-  backgroundColor: "#fff",
-  preserveObjectStacking: true,
-});
-// HiDPI scaling
-const dpr = window.devicePixelRatio || 1;
-c.setDimensions({ width: w * dpr, height: h * dpr });
-c.setViewportTransform([dpr, 0, 0, dpr, 0, 0]);
-// CSS pixel size
-if (canvasEl.current) {
-  canvasEl.current.style.width = w + "px";
-  canvasEl.current.style.height = h + "px";
-}
-localRef.current = c;
-    setCanvas(c);
-    if (ref) ref.current = c;
+
+    const instance = new fabric.Canvas(canvasEl.current, {
+      width: w,
+      height: h,
+      backgroundColor: "#fff",
+      preserveObjectStacking: true,
+    });
+
+    applyDimensions(instance, w, h);
+    setCanvas(instance);
+
     return () => {
-      c.dispose();
+      instance.dispose();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [applyDimensions]);
 
   // Update dimensions when props change (no re-instantiation)
   useEffect(() => {
     if (!canvas) return;
     const w = Number(width) || 400;
     const h = Number(height) || 550;
-    
-const dpr = window.devicePixelRatio || 1;
-if (canvas.getWidth() !== w * dpr || canvas.getHeight() !== h * dpr) {
-  canvas.setDimensions({ width: w * dpr, height: h * dpr });
-  canvas.setViewportTransform([dpr, 0, 0, dpr, 0, 0]);
-  if (canvasEl.current) {
-    canvasEl.current.style.width = w + "px";
-    canvasEl.current.style.height = h + "px";
-  }
-}
-canvas.requestRenderAll();
 
-  }, [canvas, width, height]);
+    applyDimensions(canvas, w, h);
+    canvas.requestRenderAll();
+  }, [applyDimensions, canvas, width, height]);
 
   useImperativeHandle(ref, () => canvas, [canvas]);
 


### PR DESCRIPTION
## Summary
- load template metadata from the backend and normalize the stored canvas size values
- add a blank canvas creator that lets users enter custom dimensions and resets the editor state
- harden the Fabric canvas wrapper so canvas dimensions update cleanly across desktop and mobile

## Testing
- CI=1 npm run build -- --logLevel silent

------
https://chatgpt.com/codex/tasks/task_e_68d8f61e8c388322954fe5adbddd3244