### PR TITLE
Improve editor UX with autosave, layers, and template states

### DIFF
--- a/src/components/IconButton.jsx
+++ b/src/components/IconButton.jsx
@@ -1,12 +1,13 @@
 // IconButton.jsx
 import React from "react";
 
-const IconButton = ({ onClick, title, children, className = "", ...props }) => (
+const IconButton = ({ onClick, title, children, className = "", disabled = false, ...props }) => (
   <button
     type="button"
     onClick={onClick}
     title={title}
-    className={`p-2 rounded bg-white shadow hover:bg-blue-100 ${className}`}
+    disabled={disabled}
+    className={`p-2 rounded bg-white shadow ${disabled ? "cursor-not-allowed opacity-60" : "hover:bg-blue-100"} ${className}`}
     {...props}
   >
     {children}

--- a/src/components/TemplateSidebar.jsx
+++ b/src/components/TemplateSidebar.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, memo } from "react";
+import React, { useEffect, useMemo, useState, memo } from "react";
 import axios from "axios";
 import TemplateCard from "./TemplateCard";
 
@@ -12,6 +12,7 @@ const defaultTemplates = [
 
 const TemplateSidebar = memo(({ loadTemplate }) => {
   const [saved, setSaved] = useState([]);
+  const [query, setQuery] = useState("");
 
   useEffect(() => {
     axios
@@ -20,13 +21,36 @@ const TemplateSidebar = memo(({ loadTemplate }) => {
       .catch((err) => console.error("Failed to load templates", err));
   }, []);
 
-  const templates = defaultTemplates.concat(saved);
+  const templates = useMemo(() => {
+    const list = defaultTemplates.concat(saved);
+    if (!query.trim()) return list;
+    const term = query.trim().toLowerCase();
+    return list.filter((item) => {
+      const label = (item.title || item.name || "").toLowerCase();
+      return label.includes(term);
+    });
+  }, [saved, query]);
 
   return (
-    <div className="grid grid-cols-2 gap-2 w-48 sm:w-56">
-      {templates.map((t, idx) => (
-        <TemplateCard key={idx} template={t} onSelect={loadTemplate} />
-      ))}
+    <div className="flex flex-col gap-3">
+      <div>
+        <input
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search templates"
+          className="w-full rounded border border-slate-200 bg-white px-2 py-1 text-sm focus:border-indigo-400 focus:outline-none"
+        />
+      </div>
+      {templates.length === 0 ? (
+        <p className="px-2 text-xs text-slate-500">No templates match your search.</p>
+      ) : (
+        <div className="grid w-48 grid-cols-2 gap-2 sm:w-56">
+          {templates.map((t, idx) => (
+            <TemplateCard key={idx} template={t} onSelect={loadTemplate} />
+          ))}
+        </div>
+      )}
     </div>
   );
 });

--- a/src/pages/TemplateGallery.jsx
+++ b/src/pages/TemplateGallery.jsx
@@ -1,56 +1,118 @@
 
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
 
 const LOCAL_KEY = "localTemplates";
 
+const skeletonCards = Array.from({ length: 8 }, (_, idx) => idx);
 
 const TemplateGallery = () => {
   const [templates, setTemplates] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
   const navigate = useNavigate();
 
-  useEffect(() => {
-    const fetchTemplates = async () => {
-      try {
-        const res = await axios.get("https://canvaback.onrender.com/api/template/");
-        const data = Array.isArray(res.data)
-          ? res.data
-          : Array.isArray(res.data.templates)
+  const persistTemplates = useCallback((items) => {
+    try {
+      localStorage.setItem(LOCAL_KEY, JSON.stringify(items));
+    } catch (storageError) {
+      console.warn("Unable to persist templates locally", storageError);
+    }
+  }, []);
+
+  const fetchTemplates = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await axios.get("https://canvaback.onrender.com/api/template/");
+      const data = Array.isArray(res.data)
+        ? res.data
+        : Array.isArray(res.data.templates)
           ? res.data.templates
           : res.data.result || [];
-        const mapped = data.map((t) => ({ ...t, id: t._id }));
-        setTemplates(mapped);
-        localStorage.setItem(LOCAL_KEY, JSON.stringify(mapped));
-      } catch (err) {
-        console.error("Error fetching templates", err);
+      const mapped = data.map((t) => ({ ...t, id: t._id || t.id }));
+      setTemplates(mapped);
+      persistTemplates(mapped);
+    } catch (err) {
+      console.error("Error fetching templates", err);
+      setError("Unable to reach the template service.");
+      try {
         const local = JSON.parse(localStorage.getItem(LOCAL_KEY) || "[]");
         setTemplates(local);
-        console.error("Error fetching templates", err);
+      } catch (storageError) {
+        console.error("Failed to parse cached templates", storageError);
+        setTemplates([]);
       }
-    };
+    } finally {
+      setLoading(false);
+    }
+  }, [persistTemplates]);
+
+  useEffect(() => {
     fetchTemplates();
-  }, []);
+  }, [fetchTemplates]);
+
+  const hasTemplates = templates.length > 0;
+  const emptyMessage = useMemo(() => {
+    if (loading) return "";
+    if (error && hasTemplates) return "";
+    if (error) return "We couldn\'t load templates right now.";
+    return "Start by creating your first template.";
+  }, [loading, error, hasTemplates]);
 
   return (
     <div className="p-6">
       <h1 className="text-2xl font-bold mb-4">Choose a Template</h1>
-      {templates.length === 0 ? (
-        <p>No templates found.</p>
-      ) : (
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          {templates.map((tpl) => (
-            <div
-               key={tpl.id}
-              className="bg-white shadow rounded overflow-hidden cursor-pointer hover:shadow-md"
-               onClick={() => navigate(`/editor/${tpl.id}`)}
-            >
-              {tpl.image && (
-                <img src={tpl.image} alt={tpl.title} className="h-32 w-full object-cover" />
-              )}
-              <div className="p-2 text-center font-medium">{tpl.title}</div>
+
+      {error && (
+        <div className="mb-4 rounded border border-amber-200 bg-amber-50 p-4 text-amber-800">
+          <p className="text-sm font-medium">{error}</p>
+          <button
+            type="button"
+            className="mt-2 rounded bg-amber-600 px-3 py-1 text-sm font-semibold text-white hover:bg-amber-700"
+            onClick={fetchTemplates}
+          >
+            Try again
+          </button>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+          {skeletonCards.map((idx) => (
+            <div key={idx} className="animate-pulse rounded bg-white p-2 shadow">
+              <div className="mb-3 h-32 w-full rounded bg-gray-200" />
+              <div className="mx-auto h-3 w-1/2 rounded bg-gray-200" />
             </div>
           ))}
+        </div>
+      ) : hasTemplates ? (
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+          {templates.map((tpl) => (
+            <button
+              key={tpl.id}
+              type="button"
+              className="overflow-hidden rounded bg-white text-left shadow transition hover:-translate-y-0.5 hover:shadow-lg"
+              onClick={() => navigate(`/editor/${tpl.id}`)}
+            >
+              {tpl.image ? (
+                <img src={tpl.image} alt={tpl.title || tpl.name} className="h-32 w-full object-cover" />
+              ) : (
+                <div className="flex h-32 w-full items-center justify-center bg-slate-100 text-slate-400">
+                  No preview
+                </div>
+              )}
+              <div className="p-2 text-center text-sm font-medium text-slate-700">
+                {tpl.title || tpl.name || "Untitled"}
+              </div>
+            </button>
+          ))}
+        </div>
+      ) : (
+        <div className="rounded border border-dashed border-slate-300 bg-slate-50 p-6 text-center text-slate-500">
+          <p className="font-medium">{emptyMessage}</p>
+          <p className="mt-1 text-sm">You can always design from scratch in the editor.</p>
         </div>
       )}
     </div>

--- a/src/utils/backgroundUtils.js
+++ b/src/utils/backgroundUtils.js
@@ -1,24 +1,23 @@
 export async function removeBackground(file) {
-  const apiKey = import.meta.env.VITE_REMOVE_BG_API_KEY;
-  if (!apiKey) {
-    throw new Error("Missing Remove.bg API key");
+  const endpoint = import.meta.env.VITE_BG_REMOVE_URL;
+  if (!endpoint) {
+    const error = new Error("Background removal service not configured");
+    error.code = "BG_REMOVE_URL_MISSING";
+    throw error;
   }
 
   const formData = new FormData();
+  formData.append("image", file);
   formData.append("image_file", file);
-  formData.append("size", "auto");
 
-  const response = await fetch("https://api.remove.bg/v1.0/removebg", {
+  const response = await fetch(endpoint, {
     method: "POST",
-    headers: {
-      "X-Api-Key": apiKey,
-    },
     body: formData,
   });
 
   if (!response.ok) {
     const errorText = await response.text();
-    throw new Error(`Remove.bg request failed: ${response.status} ${errorText}`);
+    throw new Error(`Background removal request failed: ${response.status} ${errorText}`);
   }
 
   return await response.blob();


### PR DESCRIPTION
## Summary
- add resilient loading, caching, and empty-state handling to the template gallery and sidebar search
- wire autosave with local restore, magic resize presets, and a layers drawer into the canvas editor
- guard background removal behind the configurable endpoint and update icon button styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9509f05e08322b74a0a9d2b0d137a