### PR TITLE
Improve canvas viewport responsiveness

### DIFF
--- a/src/components/CanvasEditor.jsx
+++ b/src/components/CanvasEditor.jsx
@@ -118,6 +118,13 @@ export function CanvasEditor({
     };
   }, [canvasRef]);
 
+  useEffect(() => {
+    if (!fabricCanvas) return;
+    const scale = zoom / 100;
+    fabricCanvas.setViewportTransform([scale, 0, 0, scale, 0, 0]);
+    fabricCanvas.requestRenderAll();
+  }, [fabricCanvas, zoom]);
+
   // Load a template when navigating from the gallery or template list
   useEffect(() => {
     if (!fabricCanvas || !templateId) return;
@@ -193,7 +200,7 @@ export function CanvasEditor({
 
       viewport={
         <Viewport stageStyle={{ width: CANVAS_WIDTH, height: CANVAS_HEIGHT }}>
-          <canvas ref={canvasElementRef} style={{ width: CANVAS_WIDTH, height: CANVAS_HEIGHT }} />
+          <canvas ref={canvasElementRef} style={{ width: "100%", height: "100%" }} />
           {loadingTemplate && (
             <div className="absolute top-2 left-1/2 -translate-x-1/2 bg-white px-4 py-1 rounded shadow text-sm text-gray-600">
               Loading template...

--- a/src/components/canvas/EditorShell.jsx
+++ b/src/components/canvas/EditorShell.jsx
@@ -9,29 +9,39 @@ const EditorShell = ({ topBar, leftToolbar, viewport, rightPanel, bottomBar }) =
     <Stack minHeight="100vh" width="100vw" bgcolor="grey.50">
       <Box flexShrink={0}>{topBar}</Box>
       <Stack direction={isMobile ? "column" : "row"} flex={1} overflow="hidden">
+        {!isMobile && (
+          <Box
+            width={288}
+            borderRight={1}
+            borderColor="divider"
+            bgcolor="background.paper"
+            overflow="auto"
+          >
+            {leftToolbar}
+          </Box>
+        )}
         <Box
-          width={isMobile ? "100%" : 288}
-          borderRight={isMobile ? 0 : 1}
-          borderColor="divider"
-          bgcolor="background.paper"
+          flex={1}
+          minHeight={0}
           overflow="auto"
-          display={isMobile ? "none" : "block"}
+          bgcolor="grey.100"
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
         >
-          {leftToolbar}
-        </Box>
-        <Box flex={1} overflow="auto" bgcolor="grey.100" display="flex" alignItems="center" justifyContent="center">
           {viewport}
         </Box>
-        <Box
-          width={isMobile ? "100%" : 320}
-          borderLeft={isMobile ? 0 : 1}
-          borderColor="divider"
-          bgcolor="background.paper"
-          overflow="auto"
-          display={isMobile ? "none" : "block"}
-        >
-          {rightPanel}
-        </Box>
+        {!isMobile && (
+          <Box
+            width={320}
+            borderLeft={1}
+            borderColor="divider"
+            bgcolor="background.paper"
+            overflow="auto"
+          >
+            {rightPanel}
+          </Box>
+        )}
       </Stack>
       <Box flexShrink={0}>{bottomBar}</Box>
     </Stack>

--- a/src/components/canvas/EditorShell.jsx
+++ b/src/components/canvas/EditorShell.jsx
@@ -1,22 +1,41 @@
 import React from "react";
-import { Box, Stack } from "@mui/material";
+import { Box, Stack, useMediaQuery, useTheme } from "@mui/material";
 
-const EditorShell = ({ topBar, leftToolbar, viewport, rightPanel, bottomBar }) => (
-  <Stack minHeight="100vh" width="100vw" bgcolor="grey.50">
-    <Box flexShrink={0}>{topBar}</Box>
-    <Stack direction="row" flex={1} overflow="hidden">
-      <Box width={288} borderRight={1} borderColor="divider" bgcolor="background.paper" overflow="auto">
-        {leftToolbar}
-      </Box>
-      <Box flex={1} overflow="auto" bgcolor="grey.100" display="flex" alignItems="center" justifyContent="center">
-        {viewport}
-      </Box>
-      <Box width={320} borderLeft={1} borderColor="divider" bgcolor="background.paper" overflow="auto">
-        {rightPanel}
-      </Box>
+const EditorShell = ({ topBar, leftToolbar, viewport, rightPanel, bottomBar }) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+
+  return (
+    <Stack minHeight="100vh" width="100vw" bgcolor="grey.50">
+      <Box flexShrink={0}>{topBar}</Box>
+      <Stack direction={isMobile ? "column" : "row"} flex={1} overflow="hidden">
+        <Box
+          width={isMobile ? "100%" : 288}
+          borderRight={isMobile ? 0 : 1}
+          borderColor="divider"
+          bgcolor="background.paper"
+          overflow="auto"
+          display={isMobile ? "none" : "block"}
+        >
+          {leftToolbar}
+        </Box>
+        <Box flex={1} overflow="auto" bgcolor="grey.100" display="flex" alignItems="center" justifyContent="center">
+          {viewport}
+        </Box>
+        <Box
+          width={isMobile ? "100%" : 320}
+          borderLeft={isMobile ? 0 : 1}
+          borderColor="divider"
+          bgcolor="background.paper"
+          overflow="auto"
+          display={isMobile ? "none" : "block"}
+        >
+          {rightPanel}
+        </Box>
+      </Stack>
+      <Box flexShrink={0}>{bottomBar}</Box>
     </Stack>
-    <Box flexShrink={0}>{bottomBar}</Box>
-  </Stack>
-);
+  );
+};
 
 export default EditorShell;

--- a/src/components/canvas/Viewport.jsx
+++ b/src/components/canvas/Viewport.jsx
@@ -1,17 +1,29 @@
 /* ------------------------- Viewport ------------------------- */
 import PropTypes from "prop-types";
 
-export function Viewport({ children, stageStyle = {}, className = '' }) {
-return (
-<div className={`p-6 flex items-center justify-center ${className}`}>
-<div style={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-<div className="shadow-md border bg-white relative" style={stageStyle}>
-{children}
-</div>
-</div>
-</div>
-);
+export function Viewport({ children, stageStyle = {}, className = "" }) {
+  const { width, height, ...rest } = stageStyle;
+  const aspectRatio = width && height ? `${width} / ${height}` : undefined;
+
+  return (
+    <div className={`w-full h-full p-4 md:p-6 flex items-center justify-center ${className}`}>
+      <div className="w-full h-full flex items-center justify-center overflow-auto">
+        <div
+          className="shadow-md border bg-white relative max-w-full"
+          style={{
+            width: "100%",
+            maxWidth: width ? `${width}px` : "100%",
+            maxHeight: "calc(100vh - 240px)",
+            aspectRatio,
+            ...rest,
+          }}
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  );
 }
-Viewport.propTypes = { children: PropTypes.node, stageStyle: PropTypes.object };
+Viewport.propTypes = { children: PropTypes.node, stageStyle: PropTypes.object, className: PropTypes.string };
 
 export default Viewport;

--- a/src/components/canvas/Viewport.jsx
+++ b/src/components/canvas/Viewport.jsx
@@ -4,17 +4,19 @@ import PropTypes from "prop-types";
 export function Viewport({ children, stageStyle = {}, className = "" }) {
   const { width, height, ...rest } = stageStyle;
   const aspectRatio = width && height ? `${width} / ${height}` : undefined;
+  const maxHeight = "calc(100vh - 160px)";
 
   return (
-    <div className={`w-full h-full p-4 md:p-6 flex items-center justify-center ${className}`}>
+    <div className={`w-full h-full p-4 md:p-6 flex items-center justify-center overflow-hidden ${className}`}>
       <div className="w-full h-full flex items-center justify-center overflow-auto">
         <div
           className="shadow-md border bg-white relative max-w-full"
           style={{
             width: "100%",
             maxWidth: width ? `${width}px` : "100%",
-            maxHeight: "calc(100vh - 240px)",
+            maxHeight,
             aspectRatio,
+            height: aspectRatio ? "auto" : "100%",
             ...rest,
           }}
         >


### PR DESCRIPTION
## Summary
- hide editor side panels on small screens so the canvas can take full width
- make the viewport container responsive with aspect ratio and max-height constraints
- tie the zoom slider to the Fabric viewport and scale the canvas element to fill its container

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e91e6cc508322b82138d22b1d511e)